### PR TITLE
Updated remCursor to use Object.keys instead of values()

### DIFF
--- a/NonBlock.es5.js
+++ b/NonBlock.es5.js
@@ -525,7 +525,10 @@
       }, {
         key: 'remCursor',
         value: function remCursor(el) {
-          [].concat(_toConsumableArray(el.classList.values())).forEach(function (className) {
+          var values = Object.keys(el.classList).map(function (e) {
+            return el.classList[e];
+          });
+          [].concat(_toConsumableArray(values)).forEach(function (className) {
             if (className.indexOf('nonblock-cursor-') === 0) {
               el.classList.remove(className);
             }

--- a/NonBlock.js
+++ b/NonBlock.js
@@ -480,7 +480,8 @@
     }
 
     remCursor(el) {
-      [...el.classList.values()].forEach((className) => {
+      const values = Object.keys(el.classList).map(e => el.classList[e]);
+      [...values].forEach((className) => {
         if (className.indexOf('nonblock-cursor-') === 0) {
           el.classList.remove(className);
         }


### PR DESCRIPTION
I've updated the code to work with IE11 without throwing an error.